### PR TITLE
Fix image generation toggle

### DIFF
--- a/backend/controllers/imageController.js
+++ b/backend/controllers/imageController.js
@@ -19,9 +19,16 @@ async function handleImageGeneration(req, res) {
       enableWebSearch: false
     })
 
+    const assistantMessage = responseData.choices[0]?.message?.content || ''
     const images = responseData.choices[0]?.message?.images || []
+
+    const message = images.length > 0
+      ? assistantMessage || 'Here is your generated image.'
+      : assistantMessage
+
     res.json({
       success: true,
+      message,
       images
     })
   } catch (error) {


### PR DESCRIPTION
## Summary
- route image generation requests through the dedicated backend endpoint so Gemini is called directly
- update the server response to include a friendly assistant message when images are returned

## Testing
- npm run lint *(fails: interactive prompt from deprecated `next lint` asking for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e6f0d2f08321abc3e559c6a7d42a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added image generation in chat: prompts can now return generated images along with an assistant message.
  - Chat UI updates to display generated images and accompanying text in the latest assistant reply.
  - Smart routing between streaming and non-streaming replies based on whether image generation is enabled.
  - Improved loading and completion handling for image-generation responses, ensuring smooth transitions and accurate status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->